### PR TITLE
Modif track name

### DIFF
--- a/src/components/pages/music/MusicPage.scss
+++ b/src/components/pages/music/MusicPage.scss
@@ -96,6 +96,8 @@
           .infos__name {
             overflow: hidden;
             font-weight: bold;
+            text-overflow: ellipsis;
+            white-space: nowrap;
           }
 
           .infos__artist {

--- a/src/components/pages/music/MusicPage.tsx
+++ b/src/components/pages/music/MusicPage.tsx
@@ -55,7 +55,7 @@ const MusicPage = () => {
       const track = {
         uuid,
         path: file.path,
-        title: tags.title || "Sans titre",
+        title: tags.title || file.name || "Sans titre",
         artist: tags.artist || "Inconnu",
         album: tags.album || "Inconnu",
         cover,


### PR DESCRIPTION
Si une musique importée n'a pas de titre dans ses meta données, on fallback sur le nom du fichier. Aussi, si le texte dépasse, ajout d'ellipse